### PR TITLE
[AB#40100] feat: build and run container as their native non-root users

### DIFF
--- a/.adops/service-build.yml
+++ b/.adops/service-build.yml
@@ -6,7 +6,7 @@ pool:
   demands: project_navy
 
 variables:
-  dockerfilePath: '.adops/docker/Dockerfile'
+  dockerfilePath: 'Dockerfile'
   tag: '$(Build.BuildNumber)'
   # Yarn Cache Folder
   YARN_CACHE_FOLDER: $(Pipeline.Workspace)/.yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ ARG PACKAGE_BUILD_COMMAND
 
 WORKDIR "/app/$PACKAGE_ROOT"
 
+RUN chown -R node:node /app
+USER node
+
 COPY --from=build ["/checkout/$PACKAGE_ROOT/package.json", "./"]
 COPY --from=build ["/checkout/node_modules", "/app/node_modules/"]
 COPY --from=build ["/checkout/$PACKAGE_ROOT/node_modules", "./node_modules/"]


### PR DESCRIPTION
<!-- Please add the related workitem into the title of the PR with the prefix 'AB#' e.g. '[[AB#36304](https://dev.azure.com/axinom/5e61ad7f-f562-45f3-8078-9ade7df639c1/_workitems/edit/36304)] This is my pull request' -->

# Pull Request

## Prerequisites

- [x] My code follows the coding conventions
- [x] All tests pass

## Description

<!-- describe your changes here -->
- Backend Service Containers (node):
   - ownership of `/app` directory is given to `node` user that is built into the standard `node:18-alpine` image and has `1000` as the `uid` and `gid`. This change was not needed for most of the services but if the app itself or a library tries to download something like geolite data, there will be a permission issue so now the ownership is given to `node` user universally
   - container is run as user `node(1000)` and group `node(1000)` with no privilege escalations